### PR TITLE
Migrate to asm4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,9 +110,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.kohsuke</groupId>
-      <artifactId>asm3</artifactId>
-      <version>3.3.0</version>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+      <version>4.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>

--- a/src/main/java/org/jenkinsci/bytecode/AdaptField.java
+++ b/src/main/java/org/jenkinsci/bytecode/AdaptField.java
@@ -1,9 +1,10 @@
 package org.jenkinsci.bytecode;
 
 import org.jvnet.hudson.annotation_indexer.Indexed;
-import org.kohsuke.asm3.MethodVisitor;
-import org.kohsuke.asm3.Type;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Type;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import java.lang.reflect.AnnotatedElement;
@@ -12,10 +13,9 @@ import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 
-import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.*;
-import static org.kohsuke.asm3.Opcodes.*;
-import static org.kohsuke.asm3.Type.*;
+import static org.objectweb.asm.Opcodes.*;
+import static org.objectweb.asm.Type.*;
 
 /**
  * Rewrites a field reference by adapting the type of the field.
@@ -36,7 +36,7 @@ import static org.kohsuke.asm3.Type.*;
  * @author Kohsuke Kawaguchi
  */
 @Retention(RUNTIME)
-@Target({FIELD,METHOD})
+@Target({ElementType.FIELD,ElementType.METHOD})
 @Indexed
 @AdapterAnnotation(AdaptField.FactoryImpl.class)
 public @interface AdaptField {

--- a/src/main/java/org/jenkinsci/bytecode/ClassRewritingContext.java
+++ b/src/main/java/org/jenkinsci/bytecode/ClassRewritingContext.java
@@ -1,16 +1,16 @@
 package org.jenkinsci.bytecode;
 
-import org.kohsuke.asm3.ClassVisitor;
-import org.kohsuke.asm3.Label;
-import org.kohsuke.asm3.MethodVisitor;
-import org.kohsuke.asm3.Opcodes;
-import org.kohsuke.asm3.Type;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import static org.kohsuke.asm3.Opcodes.*;
+import static org.objectweb.asm.Opcodes.*;
 
 /**
  * Remembers what class is being rewritten and what helper methods need to be generated into this class.

--- a/src/main/java/org/jenkinsci/bytecode/Kind.java
+++ b/src/main/java/org/jenkinsci/bytecode/Kind.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.bytecode;
 
-import org.kohsuke.asm3.MethodVisitor;
+import org.objectweb.asm.MethodVisitor;
 
 /**
  * Rewriting a method reference and a field reference takes a very similar code path,

--- a/src/main/java/org/jenkinsci/bytecode/MemberAdapter.java
+++ b/src/main/java/org/jenkinsci/bytecode/MemberAdapter.java
@@ -1,7 +1,7 @@
 package org.jenkinsci.bytecode;
 
-import org.kohsuke.asm3.MethodVisitor;
-import org.kohsuke.asm3.Type;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Type;
 
 import java.lang.reflect.Member;
 

--- a/src/main/java/org/jenkinsci/bytecode/MemberTransformSpec.java
+++ b/src/main/java/org/jenkinsci/bytecode/MemberTransformSpec.java
@@ -1,15 +1,15 @@
 package org.jenkinsci.bytecode;
 
-import org.kohsuke.asm3.Label;
-import org.kohsuke.asm3.MethodVisitor;
-import org.kohsuke.asm3.Type;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Type;
 
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import static org.kohsuke.asm3.Opcodes.*;
+import static org.objectweb.asm.Opcodes.*;
 
 /**
  * All the adapters of {@linkplain #kind a specific member type} keyed by their name and descriptor.

--- a/src/main/java/org/jenkinsci/bytecode/Transformer.java
+++ b/src/main/java/org/jenkinsci/bytecode/Transformer.java
@@ -1,12 +1,12 @@
 package org.jenkinsci.bytecode;
 
-import org.kohsuke.asm3.ClassAdapter;
-import org.kohsuke.asm3.ClassReader;
-import org.kohsuke.asm3.ClassWriter;
-import org.kohsuke.asm3.Label;
-import org.kohsuke.asm3.MethodAdapter;
-import org.kohsuke.asm3.MethodVisitor;
-import org.kohsuke.asm3.Type;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -14,7 +14,7 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.logging.Logger;
 
-import static org.kohsuke.asm3.Opcodes.*;
+import static org.objectweb.asm.Opcodes.*;
 
 /**
  * Transform byte code where code references bytecode rewrite annotations.
@@ -66,7 +66,7 @@ public class Transformer {
 
         final boolean[] modified = new boolean[1];
 
-        cr.accept(new ClassAdapter(cw) {
+        cr.accept(new ClassVisitor(Opcodes.ASM4, cw) {
             private ClassRewritingContext context;
 
             @Override
@@ -79,7 +79,7 @@ public class Transformer {
             public MethodVisitor visitMethod(int access, final String methodName, final String methodDescriptor, String methodSignature, String[] exceptions) {
                 final MethodVisitor base = super.visitMethod(access, methodName, methodDescriptor, methodSignature, exceptions);
 
-                return new MethodAdapter(base) {
+                return new MethodVisitor(Opcodes.ASM4, base) {
                     @Override
                     public void visitMethodInsn(int opcode, String owner, String name, String desc) {
                         modified[0] |= spec.methods.rewrite(context,opcode,owner,name,desc,base);


### PR DESCRIPTION
asm4 port. Initially I thought that bytecode-compatibility-transformer is only library in Jenkins which depends on renamed asm3. But It turned out that jenkins-core and stapler use renamed asm3 as well (in very limited way). Please see also my pull requests for those projects.

Thanks
