### PR TITLE
[JENKINS-28781] Fix generated bytecode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/target/
+/.settings/
+/.classpath
+/.project


### PR DESCRIPTION
This has been verified to fix [JENKINS-28781](https://issues.jenkins-ci.org/browse/JENKINS-28781) by replacing the jar in the war with a locally generated one and running the offending plugin.

unit test for old compatibility still passes, but not further testing has been performed.

The code still erroneously re-writes the class when it does not need to which still needs to be addressed.

@reviewbybees - esp @tfennelly @stephenc @kohsuke 