### PR TITLE
[WIP] Test case for [JENKINS-28799]

### DIFF
--- a/src/test/java/CompatibilityTest.java
+++ b/src/test/java/CompatibilityTest.java
@@ -1,9 +1,11 @@
 import junit.framework.TestResult;
 import junit.framework.TestSuite;
 import junit.textui.TestRunner;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.tools.ant.AntClassLoader;
 import org.jenkinsci.bytecode.Transformer;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
@@ -31,6 +33,32 @@ public class CompatibilityTest {
         assertFieldType(i, String[].class, "y");
         assertFieldType(i, Object.class, "z");
     }
+    
+    @Test
+    public void testClassesAreOnlyReWrittenWhenNeeded() throws Exception {
+        System.out.println("rewrtting tests");
+        final Transformer t = new Transformer();
+        AntClassLoader cl = new AntClassLoader() {
+            @Override
+            protected Class<?> defineClassFromData(File container, byte[] classData, String classname) throws IOException {
+                byte[] rewritten = t.transform(classname, classData);
+                if (rewritten!=classData ) {
+                    fail(classname + " was rewritten without need");
+                }
+                return super.defineClassFromData(container, rewritten, classname);
+            }
+        };
+
+        cl.addPathComponent(new File("target/test-classes/v2"));
+        cl.addPathComponent(new File("target/test-classes/client"));
+        cl.addPathComponent(new File("target/lib/ivy.jar"));
+
+        t.loadRules(cl);
+
+        cl.loadClass("org.apache.ivy.core.settings.IvySettings");
+        System.out.println("rewrtting tests - done");
+    }
+
 
     private void assertFieldType(Class<?> i, Class<?> type, String name) throws NoSuchFieldException {
         assertSame(type, i.getDeclaredField(name).getType());
@@ -69,4 +97,5 @@ public class CompatibilityTest {
         if (tr.errorCount() + tr.failureCount()>0)
             throw new Error("test failures");
     }
+
 }


### PR DESCRIPTION
Adds a test case that fails if a class is needlessly transformed: [JENKINS-28799](https://issues.jenkins-ci.org/browse/JENKINS-28799)

The fact that the class has been transformed needs to be looked at and is the root cause or
[JENKINS-28781](https://issues.jenkins-ci.org/issues/JENKINS-28781) and [JENKINS-19383](https://issues.jenkins-ci.org/issues/JENKINS-19383)

So do not merge until there is a fix - but was pushed to origin as this may need to be picked up by someone else.

@reviewbybees