### PR TITLE
[JENKINS-30820] Only regenerate StackMap for JDK6+ classes

### DIFF
--- a/src/main/java/org/jenkinsci/bytecode/AdaptField.java
+++ b/src/main/java/org/jenkinsci/bytecode/AdaptField.java
@@ -62,10 +62,12 @@ public @interface AdaptField {
             if (name.length()==0)   name = mem.getName(); // default to the same name
 
             MemberAdapter mrs = null;
-            if (e instanceof Field)
+            if (e instanceof Field) {
                 mrs = fieldToField((Field) e);
-            if (e instanceof Method)
+            }
+            if (e instanceof Method) {
                 mrs = fieldToMethod((Method) e);
+            }
             assert mrs!=null;
 
             for (Class was : af.was()) {

--- a/src/main/java/org/jenkinsci/bytecode/TransformationSpec.java
+++ b/src/main/java/org/jenkinsci/bytecode/TransformationSpec.java
@@ -19,6 +19,7 @@ import static org.jenkinsci.constant_pool_scanner.ConstantType.*;
  * Definition of what to transform.
  */
 class TransformationSpec {
+    
     /**
      * Fields by their name and type (but without the owner class) that requires rewriting.
      *
@@ -74,13 +75,18 @@ class TransformationSpec {
         try {
             ConstantPool p = ConstantPoolScanner.parse(image, FIELD_REF, METHOD_REF);
             for (FieldRefConstant r : p.list(FieldRefConstant.class)) {
-                if (fields.containsKey(new NameAndType(r)))
+                if (fields.containsKey(new NameAndType(r))) {
+                    LOGGER.log(Level.FINEST, "mayNeedTransformation returning true - fields.containsKey({0}) - {1}", new Object[] {r.getName(), r.getClazz()});
                     return true;
+                }
             }
             for (MethodRefConstant r : p.list(MethodRefConstant.class)) {
-                if (methods.containsKey(new NameAndType(r)))
+                if (methods.containsKey(new NameAndType(r))) {
+                    LOGGER.log(Level.FINEST, "mayNeedTransformation returning true - methods.containsKey({0}) - {1}", new Object[] {r.getName(), r.getClazz()});
                     return true;
+                }
             }
+            LOGGER.log(Level.FINEST, "mayNeedTransformation returning false");
             return false;
         } catch (IOException e) {
             LOGGER.log(WARNING, "Failed to parse the constant pool",e);

--- a/src/main/java/org/jenkinsci/bytecode/Transformer.java
+++ b/src/main/java/org/jenkinsci/bytecode/Transformer.java
@@ -9,6 +9,8 @@ import org.kohsuke.asm5.commons.JSRInlinerAdapter;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import static org.kohsuke.asm5.Opcodes.*;
 
@@ -18,6 +20,8 @@ import static org.kohsuke.asm5.Opcodes.*;
  * @author Kohsuke Kawaguchi
  */
 public class Transformer {
+    
+    private static Logger LOGGER = Logger.getLogger(Transformer.class.getName());
 
     private volatile TransformationSpec spec = new TransformationSpec(); // start with empty
 
@@ -54,11 +58,19 @@ public class Transformer {
      *      Transformed byte code.
      */
     public byte[] transform(final String className, byte[] image) {
+        LOGGER.log(Level.FINEST, "transform({0})", className);
         if (!spec.mayNeedTransformation(image))
             return image;
 
+        /* 
+         * StackFrames are only supported in bytecode 50 (JDK 6) and higher
+         * so there is no need to recompute them for versions less than this.
+         */
+        final boolean regenerateStackMapTable = getBytecodeVersion(image) >= 50;
+
         final ClassReader cr = new ClassReader(image);
-        final ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES|ClassWriter.COMPUTE_MAXS);
+        
+        final ClassWriter cw = new ClassWriter(regenerateStackMapTable ? ClassWriter.COMPUTE_FRAMES|ClassWriter.COMPUTE_MAXS : ClassWriter.COMPUTE_MAXS);
 
         final boolean[] modified = new boolean[1];
 
@@ -66,49 +78,83 @@ public class Transformer {
         // java.lang.RuntimeException: JSR/RET are not supported with computeFrames option
         // so inline any JSR subroutines
         ClassVisitor jsrInliner = new ClassVisitor(ASM5,cw) {
+            
             @Override
             public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
                 final MethodVisitor base = super.visitMethod(access, name, desc, signature, exceptions);
-                return new JSRInlinerAdapter(base, access, name, desc, signature, exceptions);
+                LOGGER.log(Level.FINEST, "jsrInliner.visitMethod({0}, {1}, {2}, {3}, {4})", new Object[] {access, name, desc, signature, exceptions});
+                return new JSRInlinerAdapter(ASM5, base, access, name, desc, signature, exceptions) {
+
+                   @Override
+                    public void visitEnd() {
+                        LOGGER.log(Level.FINEST, "visit end for {0}", name);
+                        super.visitEnd();
+                    } 
+                };
             }
         };
         
-        cr.accept(new ClassVisitor(ASM5,jsrInliner) {
+        cr.accept(new ClassVisitor(ASM5, regenerateStackMapTable ? jsrInliner : cw) {
             private ClassRewritingContext context;
 
             @Override
             public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
-                // version 50 (JDK 6) required to generate StackMapTable
-                super.visit(Math.max(version,50), access, name, signature, superName, interfaces);
+                // we need to set the version to at least 49 - otherwise we introduce opcodes (ldc) that are not available and things break.
+                super.visit(Math.max(version,49), access, name, signature, superName, interfaces);
                 this.context = new ClassRewritingContext(name);
             }
 
             @Override
-            public MethodVisitor visitMethod(int access, final String methodName, final String methodDescriptor, String methodSignature, String[] exceptions) {
+            public MethodVisitor visitMethod(int access, final String methodName, final String methodDescriptor, final String methodSignature, String[] exceptions) {
                 final MethodVisitor base = super.visitMethod(access, methodName, methodDescriptor, methodSignature, exceptions);
 
                 return new MethodVisitor(ASM5,base) {
                     @Override
                     public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
-                        modified[0] |= spec.methods.rewrite(context,opcode,owner,name,desc, itf, base);
+                        boolean _modified = spec.methods.rewrite(context,opcode,owner,name,desc, itf, base);
+                        modified[0] |= _modified;
+                        LOGGER.log(Level.FINEST, "{0}.{1}({2}) {3} modified",
+                                   new Object[] { className, methodName, methodSignature == null ? "" : methodSignature,
+                                                 _modified ? "was" : "was not" });
                     }
 
                     @Override
                     public void visitFieldInsn(int opcode, String owner, String name, String desc) {
-                        modified[0] |= spec.fields.rewrite(context,opcode,owner,name,desc, false, base);
+                        boolean _modified = spec.fields.rewrite(context,opcode,owner,name,desc, false, base);
+                        modified[0] |= _modified;
+                        LOGGER.log(Level.FINEST, "{0}.{1}({2}) {3} modified",
+                                   new Object[] { className, methodName, methodSignature == null ? "" : methodSignature,
+                                                 _modified ? "was" : "was not" });
                     }
                 };
             }
 
             @Override
             public void visitEnd() {
+                LOGGER.log(Level.FINEST, "visitEnd(1) for {0}", className);
                 context.generateCheckerMethods(cw);
                 super.visitEnd();
+                LOGGER.log(Level.FINEST, "visitEnd(2) for {0}", className);
             }
 
-        },cr.SKIP_FRAMES);
+        },ClassReader.SKIP_FRAMES);
 
-        if (!modified[0])  return image;            // untouched
+        if (!modified[0]) {
+            LOGGER.log(Level.FINER, "class {0} was not modified.", className);
+            return image;            // untouched
+        }
+        LOGGER.log(Level.FINER, "class {0} was modified.", className);
         return cw.toByteArray();
+    }
+    
+    /**
+     * Inspects a byte array representation of a class and returns the version of the bytecode.
+     * @param classData the class bytecode.
+     * @return an integer representing the major version of the bytecode.
+     */
+    private int getBytecodeVersion(byte[] classData) {
+        int version = (( classData[6] & 0xFF ) << 8 ) | (classData[7] & 0xFF);
+        LOGGER.log(Level.FINEST, "bytecode version is {0}", version);
+        return version;
     }
 }

--- a/src/test/java/org/jenkinsci/bytecode/CompatibilityTest.java
+++ b/src/test/java/org/jenkinsci/bytecode/CompatibilityTest.java
@@ -1,3 +1,5 @@
+package org.jenkinsci.bytecode;
+
 import junit.framework.TestResult;
 import junit.framework.TestSuite;
 import junit.textui.TestRunner;


### PR DESCRIPTION
This applies a sticky plaster onto the bct so that it does not generate stackMaps for JDK5 and lower bytecode.
The root cause still exists and can be hit for JDK6+ classes but this at least reduces the number of plugins affected.

This also adds a bucket load of logging and moves the test code into a package.

Tested with a locally patched jenkins and the batch-task-plugin

@reviewbybees /cc: @olivergondza 
[JENKINS-30820](https://issues.jenkins-ci.org/browse/JENKINS-30820)