### PR TITLE
[JENKINS-46602] Java 9 support: requires bumping asm to 6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.8</version>
         <executions>
           <execution>
             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
 
   <properties>
     <maven-release-plugin.version>2.5.2</maven-release-plugin.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.34</version>
+    <version>1.39</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>bytecode-compatibility-transformer</artifactId>
   <name>Bytecode transformation-based library for managing backward compatibility</name>
-  <version>1.9-SNAPSHOT</version>
+  <version>2.0-SNAPSHOT</version>
 
   <properties>
     <maven-release-plugin.version>2.5.2</maven-release-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -114,8 +114,8 @@
     </dependency>
     <dependency>
       <groupId>org.kohsuke</groupId>
-      <artifactId>asm5</artifactId>
-      <version>5.0.1</version>
+      <artifactId>asm6</artifactId>
+      <version>6.0_BETA</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>

--- a/src/main/java/org/jenkinsci/bytecode/AdaptField.java
+++ b/src/main/java/org/jenkinsci/bytecode/AdaptField.java
@@ -1,8 +1,8 @@
 package org.jenkinsci.bytecode;
 
 import org.jvnet.hudson.annotation_indexer.Indexed;
-import org.kohsuke.asm5.MethodVisitor;
-import org.kohsuke.asm5.Type;
+import org.kohsuke.asm6.MethodVisitor;
+import org.kohsuke.asm6.Type;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -14,7 +14,7 @@ import java.lang.reflect.Modifier;
 
 import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.*;
-import static org.kohsuke.asm5.Opcodes.*;
+import static org.kohsuke.asm6.Opcodes.*;
 
 /**
  * Rewrites a field reference by adapting the type of the field.

--- a/src/main/java/org/jenkinsci/bytecode/ClassRewritingContext.java
+++ b/src/main/java/org/jenkinsci/bytecode/ClassRewritingContext.java
@@ -1,16 +1,16 @@
 package org.jenkinsci.bytecode;
 
-import org.kohsuke.asm5.ClassVisitor;
-import org.kohsuke.asm5.Label;
-import org.kohsuke.asm5.MethodVisitor;
-import org.kohsuke.asm5.Opcodes;
-import org.kohsuke.asm5.Type;
+import org.kohsuke.asm6.ClassVisitor;
+import org.kohsuke.asm6.Label;
+import org.kohsuke.asm6.MethodVisitor;
+import org.kohsuke.asm6.Opcodes;
+import org.kohsuke.asm6.Type;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import static org.kohsuke.asm5.Opcodes.*;
+import static org.kohsuke.asm6.Opcodes.*;
 
 /**
  * Remembers what class is being rewritten and what helper methods need to be generated into this class.

--- a/src/main/java/org/jenkinsci/bytecode/Kind.java
+++ b/src/main/java/org/jenkinsci/bytecode/Kind.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.bytecode;
 
-import org.kohsuke.asm5.MethodVisitor;
+import org.kohsuke.asm6.MethodVisitor;
 
 /**
  * Rewriting a method reference and a field reference takes a very similar code path,

--- a/src/main/java/org/jenkinsci/bytecode/MemberAdapter.java
+++ b/src/main/java/org/jenkinsci/bytecode/MemberAdapter.java
@@ -1,7 +1,7 @@
 package org.jenkinsci.bytecode;
 
-import org.kohsuke.asm5.MethodVisitor;
-import org.kohsuke.asm5.Type;
+import org.kohsuke.asm6.MethodVisitor;
+import org.kohsuke.asm6.Type;
 
 import java.lang.reflect.Member;
 

--- a/src/main/java/org/jenkinsci/bytecode/MemberTransformSpec.java
+++ b/src/main/java/org/jenkinsci/bytecode/MemberTransformSpec.java
@@ -1,15 +1,15 @@
 package org.jenkinsci.bytecode;
 
-import org.kohsuke.asm5.Label;
-import org.kohsuke.asm5.MethodVisitor;
-import org.kohsuke.asm5.Type;
+import org.kohsuke.asm6.Label;
+import org.kohsuke.asm6.MethodVisitor;
+import org.kohsuke.asm6.Type;
 
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import static org.kohsuke.asm5.Opcodes.*;
+import static org.kohsuke.asm6.Opcodes.*;
 
 /**
  * All the adapters of {@linkplain #kind a specific member type} keyed by their name and descriptor.

--- a/src/main/java/org/jenkinsci/bytecode/NonClassLoadingClassWriter.java
+++ b/src/main/java/org/jenkinsci/bytecode/NonClassLoadingClassWriter.java
@@ -27,7 +27,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.jenkinsci.bytecode.helper.ClassLoadingReferenceTypeHierachyReader;
-import org.kohsuke.asm5.ClassWriter;
+import org.kohsuke.asm6.ClassWriter;
 
 
 

--- a/src/main/java/org/jenkinsci/bytecode/Transformer.java
+++ b/src/main/java/org/jenkinsci/bytecode/Transformer.java
@@ -1,10 +1,10 @@
 package org.jenkinsci.bytecode;
 
-import org.kohsuke.asm5.ClassReader;
-import org.kohsuke.asm5.ClassVisitor;
-import org.kohsuke.asm5.ClassWriter;
-import org.kohsuke.asm5.MethodVisitor;
-import org.kohsuke.asm5.commons.JSRInlinerAdapter;
+import org.kohsuke.asm6.ClassReader;
+import org.kohsuke.asm6.ClassVisitor;
+import org.kohsuke.asm6.ClassWriter;
+import org.kohsuke.asm6.MethodVisitor;
+import org.kohsuke.asm6.commons.JSRInlinerAdapter;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -12,7 +12,7 @@ import java.util.Collections;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static org.kohsuke.asm5.Opcodes.*;
+import static org.kohsuke.asm6.Opcodes.*;
 
 /**
  * Transform byte code where code references bytecode rewrite annotations.

--- a/src/main/java/org/jenkinsci/bytecode/helper/ClassLoadingReferenceTypeHierachyReader.java
+++ b/src/main/java/org/jenkinsci/bytecode/helper/ClassLoadingReferenceTypeHierachyReader.java
@@ -28,8 +28,8 @@ import java.io.InputStream;
 import java.net.URL;
 
 import org.apache.commons.io.IOUtils;
-import org.kohsuke.asm5.ClassReader;
-import org.kohsuke.asm5.Type;
+import org.kohsuke.asm6.ClassReader;
+import org.kohsuke.asm6.Type;
 
 /**
  * A {@link TypeHierarchyReader} that uses a given ClassLoader to locate class definitions.

--- a/src/main/java/org/jenkinsci/bytecode/helper/TypeHierarchyReader.java
+++ b/src/main/java/org/jenkinsci/bytecode/helper/TypeHierarchyReader.java
@@ -34,8 +34,8 @@ package org.jenkinsci.bytecode.helper;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
-import static org.kohsuke.asm5.Opcodes.ACC_INTERFACE;
-import static org.kohsuke.asm5.Type.getType;
+import static org.kohsuke.asm6.Opcodes.ACC_INTERFACE;
+import static org.kohsuke.asm6.Type.getType;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -44,8 +44,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.kohsuke.asm5.ClassReader;
-import org.kohsuke.asm5.Type;
+import org.kohsuke.asm6.ClassReader;
+import org.kohsuke.asm6.Type;
 
 import static org.jenkinsci.bytecode.helper.TypeHierarchyReader.TypeHierarchy.BOOLEAN_HIERARCHY;
 import static org.jenkinsci.bytecode.helper.TypeHierarchyReader.TypeHierarchy.BYTE_HIERARCHY;

--- a/src/test/java/org/jenkinsci/bytecode/NonClassLoadingClassWriterTest.java
+++ b/src/test/java/org/jenkinsci/bytecode/NonClassLoadingClassWriterTest.java
@@ -37,8 +37,8 @@ import java.util.TreeSet;
 
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
-import org.kohsuke.asm5.ClassWriter;
-import org.kohsuke.asm5.Opcodes;
+import org.kohsuke.asm6.ClassWriter;
+import org.kohsuke.asm6.Opcodes;
 
 import static org.junit.Assert.assertThat;
 import static org.hamcrest.core.Is.is;


### PR DESCRIPTION
To support Java 9+, we need to bump to ASM 6.

@reviewbybees 