### PR TITLE
Cleanup and enable findbugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,14 @@
-/target/
-/.settings/
-/.classpath
-/.project
+target/
+work/
+
+# IntelliJ project files
+*.iml
+*.ipr
+*.iws
+.idea
+
+# eclipse project file
+.settings
+.classpath
+.project
+build

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
 
   <properties>
     <maven-release-plugin.version>2.5.2</maven-release-plugin.version>
+    <findbugs.failOnError>true</findbugs.failOnError>
   </properties>
   <build>
     <plugins>
@@ -94,6 +95,23 @@
                 </artifactItem>
               </artifactItems>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <version>3.0.5</version>
+        <configuration>
+          <failOnError>${findbugs.failOnError}</failOnError>
+        </configuration>
+        <executions>
+          <execution>
+            <id>findbugs</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>verify</phase>
           </execution>
         </executions>
       </plugin>

--- a/src/main/java/org/jenkinsci/bytecode/NameAndType.java
+++ b/src/main/java/org/jenkinsci/bytecode/NameAndType.java
@@ -24,6 +24,9 @@ final class NameAndType {
 
     @Override
     public boolean equals(Object o) {
+        if (o == null || !(o instanceof NameAndType)) {
+            return false;
+        }
         NameAndType that = (NameAndType) o;
         return descriptor.equals(that.descriptor) && name.equals(that.name);
 


### PR DESCRIPTION
Followup of https://github.com/jenkinsci/bytecode-compatibility-transformer/pull/9 where actually I realized `FindBugs` is run in CI explictly, but not by default... Hence that failure (which was actually pre-existing, wondering how/went this went through, possibly before that config changed in default CI job).

Side note: we should probably a Jenkinsfile here to be built on ci.jenkins.io

@reviewbybees esp. @jglick @jtnord and @daniel-beck who already had a look at https://github.com/jenkinsci/bytecode-compatibility-transformer/pull/9