### PR TITLE
[JENKINS-64479] do not use JUL by default for logging

### DIFF
--- a/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/NonClassLoadingClassWriter.java
+++ b/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/NonClassLoadingClassWriter.java
@@ -27,6 +27,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.jenkinsci.bytecode.helper.ClassLoadingReferenceTypeHierachyReader;
+import org.jenkinsci.bytecode.helper.LoggingHelper;
+
 import org.kohsuke.asm6.ClassWriter;
 
 
@@ -67,7 +69,7 @@ final class NonClassLoadingClassWriter extends ClassWriter {
      */
     @Override
     protected String getCommonSuperClass(final String type1, final String type2) {
-        LOGGER.log(Level.FINEST, "getCommonSuperClass({0}, {1})" , new Object[] {type1, type2});
+        LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, () -> "getCommonSuperClass(" + type1 + ", " + type2 +")");
         ClassLoadingReferenceTypeHierachyReader hr = new ClassLoadingReferenceTypeHierachyReader(classLoader);
         return hr.getCommonSuperClass(type1, type2);
     }

--- a/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/TransformationSpec.java
+++ b/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/TransformationSpec.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.bytecode;
 
+import org.jenkinsci.bytecode.helper.LoggingHelper;
 import org.jenkinsci.constant_pool_scanner.ConstantPool;
 import org.jenkinsci.constant_pool_scanner.ConstantPoolScanner;
 import org.jenkinsci.constant_pool_scanner.FieldRefConstant;
@@ -12,7 +13,6 @@ import java.lang.reflect.AnnotatedElement;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static java.util.logging.Level.*;
 import static org.jenkinsci.constant_pool_scanner.ConstantType.*;
 
 /**
@@ -53,11 +53,8 @@ class TransformationSpec {
             AdapterAnnotation aa = annotation.getAnnotation(AdapterAnnotation.class);
             try {
                 f = aa.value().newInstance();
-            } catch (InstantiationException e) {
-                LOGGER.log(Level.WARNING, "Failed to instantiate "+aa.value(),e);
-                continue;
-            } catch (IllegalAccessException e) {
-                LOGGER.log(Level.WARNING, "Failed to instantiate " + aa.value(), e);
+            } catch (IllegalAccessException | InstantiationException e) {
+                LoggingHelper.conditionallyLog(LOGGER, Level.WARNING, () -> "Failed to instantiate "+aa.value(), e);
                 continue;
             }
 
@@ -76,20 +73,20 @@ class TransformationSpec {
             ConstantPool p = ConstantPoolScanner.parse(image, FIELD_REF, METHOD_REF);
             for (FieldRefConstant r : p.list(FieldRefConstant.class)) {
                 if (fields.containsKey(new NameAndType(r))) {
-                    LOGGER.log(Level.FINEST, "mayNeedTransformation returning true - fields.containsKey({0}) - {1}", new Object[] {r.getName(), r.getClazz()});
+                    LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, () -> "mayNeedTransformation returning true - fields.containsKey(" +r.getName() + ") - " + r.getClazz());
                     return true;
                 }
             }
             for (MethodRefConstant r : p.list(MethodRefConstant.class)) {
                 if (methods.containsKey(new NameAndType(r))) {
-                    LOGGER.log(Level.FINEST, "mayNeedTransformation returning true - methods.containsKey({0}) - {1}", new Object[] {r.getName(), r.getClazz()});
+                    LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, () -> "mayNeedTransformation returning true - methods.containsKey(" +r.getName() + ") - " + r.getClazz());
                     return true;
                 }
             }
-            LOGGER.log(Level.FINEST, "mayNeedTransformation returning false");
+            LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, () -> "mayNeedTransformation returning false");
             return false;
         } catch (IOException e) {
-            LOGGER.log(WARNING, "Failed to parse the constant pool",e);
+            LoggingHelper.conditionallyLog(LOGGER, Level.WARNING, () -> "Failed to parse the constant pool", e);
             return false;
         }
     }

--- a/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/Transformer.java
+++ b/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/Transformer.java
@@ -6,6 +6,8 @@ import org.kohsuke.asm6.ClassWriter;
 import org.kohsuke.asm6.MethodVisitor;
 import org.kohsuke.asm6.commons.JSRInlinerAdapter;
 
+import org.jenkinsci.bytecode.helper.LoggingHelper;
+
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
@@ -76,9 +78,9 @@ public class Transformer {
      *      Transformed byte code.
      */
     public byte[] transform(final String className, byte[] image, ClassLoader classLoader) {
-        LOGGER.log(Level.FINEST, "transform({0}, {1})", new Object[] {className, classLoader});
+        LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, () -> "transform(" + className + ", " + classLoader + ")");
         if (!spec.mayNeedTransformation(image)) {
-            LOGGER.log(Level.FINEST, "no transformation required for {0}", className);
+            LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, () -> "no transformation required for "+  className);
             return image;
         }
         /* 
@@ -100,13 +102,13 @@ public class Transformer {
             @Override
             public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
                 final MethodVisitor base = super.visitMethod(access, name, desc, signature, exceptions);
-                LOGGER.log(Level.FINEST, "jsrInliner.visitMethod({0}, {1}, {2}, {3}, {4})", new Object[] {access, name, desc, signature, exceptions});
+                LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, () -> "jsrInliner.visitMethod(" + access + ", " + name + ", " + desc+ ", " + signature + ", " + exceptions + ")");
                 return new JSRInlinerAdapter(ASM5, base, access, name, desc, signature, exceptions) {
 
                    @Override
                     public void visitEnd() {
-                        LOGGER.log(Level.FINEST, "visit end for {0}", name);
-                        super.visitEnd();
+                       LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, () -> "visit end for " + name);
+                       super.visitEnd();
                     } 
                 };
             }
@@ -131,37 +133,37 @@ public class Transformer {
                     public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
                         boolean _modified = spec.methods.rewrite(context,opcode,owner,name,desc, itf, base);
                         modified[0] |= _modified;
-                        LOGGER.log(Level.FINEST, "{0}.{1}({2}) {3} modified",
-                                   new Object[] { className, methodName, methodSignature == null ? "" : methodSignature,
-                                                 _modified ? "was" : "was not" });
+                        LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, 
+                                () -> className + "." + methodName + "(" + (methodSignature == null ? "": methodSignature) + ") " + 
+                                     (_modified ? "was modified" : "was not modified"));
                     }
 
                     @Override
                     public void visitFieldInsn(int opcode, String owner, String name, String desc) {
                         boolean _modified = spec.fields.rewrite(context,opcode,owner,name,desc, false, base);
                         modified[0] |= _modified;
-                        LOGGER.log(Level.FINEST, "{0}.{1}({2}) {3} modified",
-                                   new Object[] { className, methodName, methodSignature == null ? "" : methodSignature,
-                                                 _modified ? "was" : "was not" });
+                        LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, 
+                                () -> className + "." + methodName + "(" + (methodSignature == null ? "": methodSignature) + ") " + 
+                                     (_modified ? "was modified" : "was not modified"));
                     }
                 };
             }
 
             @Override
             public void visitEnd() {
-                LOGGER.log(Level.FINEST, "visitEnd(1) for {0}", className);
+                LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, () -> "visitEnd(1) for " + className);
                 context.generateCheckerMethods(cw);
                 super.visitEnd();
-                LOGGER.log(Level.FINEST, "visitEnd(2) for {0}", className);
+                LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, () -> "visitEnd(2) for " + className);
             }
 
         },ClassReader.SKIP_FRAMES);
 
         if (!modified[0]) {
-            LOGGER.log(Level.FINER, "class {0} was not modified.", className);
+            LoggingHelper.conditionallyLog(LOGGER, Level.FINER, () -> "class " + className + " was not modified.");
             return image;            // untouched
         }
-        LOGGER.log(Level.FINER, "class {0} was modified.", className);
+        LoggingHelper.conditionallyLog(LOGGER, Level.FINER, () -> "class " + className + " was modified.");
         return cw.toByteArray();
     }
     
@@ -172,7 +174,7 @@ public class Transformer {
      */
     private int getBytecodeVersion(byte[] classData) {
         int version = (( classData[6] & 0xFF ) << 8 ) | (classData[7] & 0xFF);
-        LOGGER.log(Level.FINEST, "bytecode version is {0}", version);
+        LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, () -> "bytecode version is " + version);
         return version;
     }
 }

--- a/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/helper/LoggingHelper.java
+++ b/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/helper/LoggingHelper.java
@@ -1,0 +1,48 @@
+package org.jenkinsci.bytecode.helper;
+
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public final class LoggingHelper {
+
+    /**
+     * Flag to allow the use if JUL (useful sometimes to get logging in a single place, but can cause deadlocks!)
+     */
+    public static final boolean JUL_ENABLED = Boolean.getBoolean(LoggingHelper.class.getName() + ".enableJUL");
+
+    /** 
+     * Logs to JUL if {@link #JUL_ENABLED} is true, otherwise prints the message to System.out 
+     * @param log the Logger to use if JUL is enabled (and whose level will be checked to see if we should log at all
+     * @param level One of the message level identifiers, e.g., SEVERE
+     * @param supplier A function, which when called, produces the desired log message
+     */
+    public static void conditionallyLog(Logger log, Level level, Supplier<String> supplier) {
+        if (log.isLoggable(level)) {
+            if (JUL_ENABLED) {
+                log.log(level, supplier);
+            } else {
+                System.out.println(log.getName() + " [" + level.getName() + "]" + supplier.get());
+            }
+        }
+    }
+
+    /** 
+     * Logs to JUL if {@link #JUL_ENABLED} is true, otherwise prints the message to System.out 
+     * @param log the Logger to use if JUL is enabled (and whose level will be checked to see if we should log at all
+     * @param level One of the message level identifiers, e.g., SEVERE
+     * @param supplier A function, which when called, produces the desired log message
+     * @param t Throwable to associated with log message.
+     */
+    public static void conditionallyLog(Logger log, Level level, Supplier<String> supplier, Throwable t) {
+        if (log.isLoggable(level)) {
+            if (JUL_ENABLED) {
+                log.log(level, t, supplier);
+            } else {
+                System.out.println(log.getName() + " [" + level.getName() + "]" + supplier.get());
+                t.printStackTrace(System.out);
+            }
+        }
+    }
+
+}

--- a/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/helper/LoggingHelper.java
+++ b/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/helper/LoggingHelper.java
@@ -4,6 +4,12 @@ import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ * Helper utility to direct logging to either System.out or the given Logger (if enabled).
+ * We need this intermediate as logging can cause classloading and also involves locks, and the transformer is only ever
+ * invoked during class loading - so we should not really use logging as we could end up in a deadlock (however there
+ * are times where we really want to use it)
+ */
 public final class LoggingHelper {
 
     /**


### PR DESCRIPTION
[JENKINS-64479](https://issues.jenkins.io/browse/JENKINS-64479)
Logging during classloading is a surefire way to deadlock.
but we still want to have logs and in some cases we also want those logs
to be in the same place as other logs.

so introduce a new helper that will either output to System.out
(default) or use JUL (opt in) at the risk of deadlocks