### PR TITLE
[JENKINS-64479] ensure all logging is async to avoid deadlocks

### DIFF
--- a/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/NonClassLoadingClassWriter.java
+++ b/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/NonClassLoadingClassWriter.java
@@ -69,7 +69,7 @@ final class NonClassLoadingClassWriter extends ClassWriter {
      */
     @Override
     protected String getCommonSuperClass(final String type1, final String type2) {
-        LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, "getCommonSuperClass({0}, {1})" , new Object[] {type1, type2});
+        LoggingHelper.asyncLog(LOGGER, Level.FINEST, "getCommonSuperClass({0}, {1})" , new Object[] {type1, type2});
         ClassLoadingReferenceTypeHierachyReader hr = new ClassLoadingReferenceTypeHierachyReader(classLoader);
         return hr.getCommonSuperClass(type1, type2);
     }

--- a/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/NonClassLoadingClassWriter.java
+++ b/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/NonClassLoadingClassWriter.java
@@ -27,6 +27,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.jenkinsci.bytecode.helper.ClassLoadingReferenceTypeHierachyReader;
+import org.jenkinsci.bytecode.helper.LoggingHelper;
+
 import org.kohsuke.asm6.ClassWriter;
 
 
@@ -67,7 +69,7 @@ final class NonClassLoadingClassWriter extends ClassWriter {
      */
     @Override
     protected String getCommonSuperClass(final String type1, final String type2) {
-        LOGGER.log(Level.FINEST, "getCommonSuperClass({0}, {1})" , new Object[] {type1, type2});
+        LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, "getCommonSuperClass({0}, {1})" , new Object[] {type1, type2});
         ClassLoadingReferenceTypeHierachyReader hr = new ClassLoadingReferenceTypeHierachyReader(classLoader);
         return hr.getCommonSuperClass(type1, type2);
     }

--- a/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/TransformationSpec.java
+++ b/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/TransformationSpec.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.bytecode;
 
+import org.jenkinsci.bytecode.helper.LoggingHelper;
 import org.jenkinsci.constant_pool_scanner.ConstantPool;
 import org.jenkinsci.constant_pool_scanner.ConstantPoolScanner;
 import org.jenkinsci.constant_pool_scanner.FieldRefConstant;
@@ -12,7 +13,6 @@ import java.lang.reflect.AnnotatedElement;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static java.util.logging.Level.*;
 import static org.jenkinsci.constant_pool_scanner.ConstantType.*;
 
 /**
@@ -54,10 +54,10 @@ class TransformationSpec {
             try {
                 f = aa.value().newInstance();
             } catch (InstantiationException e) {
-                LOGGER.log(Level.WARNING, "Failed to instantiate "+aa.value(),e);
+                LoggingHelper.conditionallyLog(LOGGER, Level.WARNING, e, "Failed to instantiate {0}", aa.value());
                 continue;
             } catch (IllegalAccessException e) {
-                LOGGER.log(Level.WARNING, "Failed to instantiate " + aa.value(), e);
+                LoggingHelper.conditionallyLog(LOGGER, Level.WARNING, e, "Failed to instantiate {0}", aa.value());
                 continue;
             }
 
@@ -76,20 +76,20 @@ class TransformationSpec {
             ConstantPool p = ConstantPoolScanner.parse(image, FIELD_REF, METHOD_REF);
             for (FieldRefConstant r : p.list(FieldRefConstant.class)) {
                 if (fields.containsKey(new NameAndType(r))) {
-                    LOGGER.log(Level.FINEST, "mayNeedTransformation returning true - fields.containsKey({0}) - {1}", new Object[] {r.getName(), r.getClazz()});
+                    LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, "mayNeedTransformation returning true - fields.containsKey({0}) - {1}", r.getName(), r.getClazz());
                     return true;
                 }
             }
             for (MethodRefConstant r : p.list(MethodRefConstant.class)) {
                 if (methods.containsKey(new NameAndType(r))) {
-                    LOGGER.log(Level.FINEST, "mayNeedTransformation returning true - methods.containsKey({0}) - {1}", new Object[] {r.getName(), r.getClazz()});
+                    LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, "mayNeedTransformation returning true - methods.containsKey({0}) - {1}", r.getName(), r.getClazz());
                     return true;
                 }
             }
-            LOGGER.log(Level.FINEST, "mayNeedTransformation returning false");
+            LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, "mayNeedTransformation returning false");
             return false;
         } catch (IOException e) {
-            LOGGER.log(WARNING, "Failed to parse the constant pool",e);
+            LoggingHelper.conditionallyLog(LOGGER, Level.WARNING, e, "Failed to parse the constant pool");
             return false;
         }
     }

--- a/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/TransformationSpec.java
+++ b/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/TransformationSpec.java
@@ -54,10 +54,10 @@ class TransformationSpec {
             try {
                 f = aa.value().newInstance();
             } catch (InstantiationException e) {
-                LoggingHelper.conditionallyLog(LOGGER, Level.WARNING, e, "Failed to instantiate {0}", aa.value());
+                LoggingHelper.asyncLog(LOGGER, Level.WARNING, e, "Failed to instantiate {0}", aa.value());
                 continue;
             } catch (IllegalAccessException e) {
-                LoggingHelper.conditionallyLog(LOGGER, Level.WARNING, e, "Failed to instantiate {0}", aa.value());
+                LoggingHelper.asyncLog(LOGGER, Level.WARNING, e, "Failed to instantiate {0}", aa.value());
                 continue;
             }
 
@@ -76,20 +76,20 @@ class TransformationSpec {
             ConstantPool p = ConstantPoolScanner.parse(image, FIELD_REF, METHOD_REF);
             for (FieldRefConstant r : p.list(FieldRefConstant.class)) {
                 if (fields.containsKey(new NameAndType(r))) {
-                    LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, "mayNeedTransformation returning true - fields.containsKey({0}) - {1}", r.getName(), r.getClazz());
+                    LoggingHelper.asyncLog(LOGGER, Level.FINEST, "mayNeedTransformation returning true - fields.containsKey({0}) - {1}", r.getName(), r.getClazz());
                     return true;
                 }
             }
             for (MethodRefConstant r : p.list(MethodRefConstant.class)) {
                 if (methods.containsKey(new NameAndType(r))) {
-                    LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, "mayNeedTransformation returning true - methods.containsKey({0}) - {1}", r.getName(), r.getClazz());
+                    LoggingHelper.asyncLog(LOGGER, Level.FINEST, "mayNeedTransformation returning true - methods.containsKey({0}) - {1}", r.getName(), r.getClazz());
                     return true;
                 }
             }
-            LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, "mayNeedTransformation returning false");
+            LoggingHelper.asyncLog(LOGGER, Level.FINEST, "mayNeedTransformation returning false");
             return false;
         } catch (IOException e) {
-            LoggingHelper.conditionallyLog(LOGGER, Level.WARNING, e, "Failed to parse the constant pool");
+            LoggingHelper.asyncLog(LOGGER, Level.WARNING, e, "Failed to parse the constant pool");
             return false;
         }
     }

--- a/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/Transformer.java
+++ b/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/Transformer.java
@@ -6,6 +6,8 @@ import org.kohsuke.asm6.ClassWriter;
 import org.kohsuke.asm6.MethodVisitor;
 import org.kohsuke.asm6.commons.JSRInlinerAdapter;
 
+import org.jenkinsci.bytecode.helper.LoggingHelper;
+
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
@@ -76,9 +78,9 @@ public class Transformer {
      *      Transformed byte code.
      */
     public byte[] transform(final String className, byte[] image, ClassLoader classLoader) {
-        LOGGER.log(Level.FINEST, "transform({0}, {1})", new Object[] {className, classLoader});
+        LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, "transform({0}, {1})", className, classLoader);
         if (!spec.mayNeedTransformation(image)) {
-            LOGGER.log(Level.FINEST, "no transformation required for {0}", className);
+            LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, "no transformation required for {0}", className);
             return image;
         }
         /* 
@@ -100,13 +102,13 @@ public class Transformer {
             @Override
             public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
                 final MethodVisitor base = super.visitMethod(access, name, desc, signature, exceptions);
-                LOGGER.log(Level.FINEST, "jsrInliner.visitMethod({0}, {1}, {2}, {3}, {4})", new Object[] {access, name, desc, signature, exceptions});
+                LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, "jsrInliner.visitMethod({0}, {1}, {2}, {3}, {4})", access, name, desc, signature, exceptions);
                 return new JSRInlinerAdapter(ASM5, base, access, name, desc, signature, exceptions) {
 
                    @Override
                     public void visitEnd() {
-                        LOGGER.log(Level.FINEST, "visit end for {0}", name);
-                        super.visitEnd();
+                       LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, "visit end for {0}", name);
+                       super.visitEnd();
                     } 
                 };
             }
@@ -131,37 +133,37 @@ public class Transformer {
                     public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
                         boolean _modified = spec.methods.rewrite(context,opcode,owner,name,desc, itf, base);
                         modified[0] |= _modified;
-                        LOGGER.log(Level.FINEST, "{0}.{1}({2}) {3} modified",
-                                   new Object[] { className, methodName, methodSignature == null ? "" : methodSignature,
-                                                 _modified ? "was" : "was not" });
+                        LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, "{0}.{1}({2}) {3} modified",
+                                   className, methodName, methodSignature == null ? "" : methodSignature,
+                                                 _modified ? "was" : "was not" );
                     }
 
                     @Override
                     public void visitFieldInsn(int opcode, String owner, String name, String desc) {
                         boolean _modified = spec.fields.rewrite(context,opcode,owner,name,desc, false, base);
                         modified[0] |= _modified;
-                        LOGGER.log(Level.FINEST, "{0}.{1}({2}) {3} modified",
-                                   new Object[] { className, methodName, methodSignature == null ? "" : methodSignature,
-                                                 _modified ? "was" : "was not" });
+                        LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, "{0}.{1}({2}) {3} modified",
+                                   className, methodName, methodSignature == null ? "" : methodSignature,
+                                                 _modified ? "was" : "was not" );
                     }
                 };
             }
 
             @Override
             public void visitEnd() {
-                LOGGER.log(Level.FINEST, "visitEnd(1) for {0}", className);
+                LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, "visitEnd(1) for {0}", className);
                 context.generateCheckerMethods(cw);
                 super.visitEnd();
-                LOGGER.log(Level.FINEST, "visitEnd(2) for {0}", className);
+                LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, "visitEnd(2) for {0}", className);
             }
 
         },ClassReader.SKIP_FRAMES);
 
         if (!modified[0]) {
-            LOGGER.log(Level.FINER, "class {0} was not modified.", className);
+            LoggingHelper.conditionallyLog(LOGGER, Level.FINER, "class {0} was not modified.", className);
             return image;            // untouched
         }
-        LOGGER.log(Level.FINER, "class {0} was modified.", className);
+        LoggingHelper.conditionallyLog(LOGGER, Level.FINER, "class {0} was modified.", className);
         return cw.toByteArray();
     }
     
@@ -172,7 +174,7 @@ public class Transformer {
      */
     private int getBytecodeVersion(byte[] classData) {
         int version = (( classData[6] & 0xFF ) << 8 ) | (classData[7] & 0xFF);
-        LOGGER.log(Level.FINEST, "bytecode version is {0}", version);
+        LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, "bytecode version is {0}", version);
         return version;
     }
 }

--- a/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/Transformer.java
+++ b/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/Transformer.java
@@ -78,9 +78,9 @@ public class Transformer {
      *      Transformed byte code.
      */
     public byte[] transform(final String className, byte[] image, ClassLoader classLoader) {
-        LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, "transform({0}, {1})", className, classLoader);
+        LoggingHelper.asyncLog(LOGGER, Level.FINEST, "transform({0}, {1})", className, classLoader);
         if (!spec.mayNeedTransformation(image)) {
-            LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, "no transformation required for {0}", className);
+            LoggingHelper.asyncLog(LOGGER, Level.FINEST, "no transformation required for {0}", className);
             return image;
         }
         /* 
@@ -102,12 +102,12 @@ public class Transformer {
             @Override
             public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
                 final MethodVisitor base = super.visitMethod(access, name, desc, signature, exceptions);
-                LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, "jsrInliner.visitMethod({0}, {1}, {2}, {3}, {4})", access, name, desc, signature, exceptions);
+                LoggingHelper.asyncLog(LOGGER, Level.FINEST, "jsrInliner.visitMethod({0}, {1}, {2}, {3}, {4})", access, name, desc, signature, exceptions);
                 return new JSRInlinerAdapter(ASM5, base, access, name, desc, signature, exceptions) {
 
                    @Override
                     public void visitEnd() {
-                       LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, "visit end for {0}", name);
+                       LoggingHelper.asyncLog(LOGGER, Level.FINEST, "visit end for {0}", name);
                        super.visitEnd();
                     } 
                 };
@@ -133,7 +133,7 @@ public class Transformer {
                     public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
                         boolean _modified = spec.methods.rewrite(context,opcode,owner,name,desc, itf, base);
                         modified[0] |= _modified;
-                        LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, "{0}.{1}({2}) {3} modified",
+                        LoggingHelper.asyncLog(LOGGER, Level.FINEST, "{0}.{1}({2}) {3} modified",
                                    className, methodName, methodSignature == null ? "" : methodSignature,
                                                  _modified ? "was" : "was not" );
                     }
@@ -142,7 +142,7 @@ public class Transformer {
                     public void visitFieldInsn(int opcode, String owner, String name, String desc) {
                         boolean _modified = spec.fields.rewrite(context,opcode,owner,name,desc, false, base);
                         modified[0] |= _modified;
-                        LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, "{0}.{1}({2}) {3} modified",
+                        LoggingHelper.asyncLog(LOGGER, Level.FINEST, "{0}.{1}({2}) {3} modified",
                                    className, methodName, methodSignature == null ? "" : methodSignature,
                                                  _modified ? "was" : "was not" );
                     }
@@ -151,19 +151,19 @@ public class Transformer {
 
             @Override
             public void visitEnd() {
-                LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, "visitEnd(1) for {0}", className);
+                LoggingHelper.asyncLog(LOGGER, Level.FINEST, "visitEnd(1) for {0}", className);
                 context.generateCheckerMethods(cw);
                 super.visitEnd();
-                LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, "visitEnd(2) for {0}", className);
+                LoggingHelper.asyncLog(LOGGER, Level.FINEST, "visitEnd(2) for {0}", className);
             }
 
         },ClassReader.SKIP_FRAMES);
 
         if (!modified[0]) {
-            LoggingHelper.conditionallyLog(LOGGER, Level.FINER, "class {0} was not modified.", className);
+            LoggingHelper.asyncLog(LOGGER, Level.FINER, "class {0} was not modified.", className);
             return image;            // untouched
         }
-        LoggingHelper.conditionallyLog(LOGGER, Level.FINER, "class {0} was modified.", className);
+        LoggingHelper.asyncLog(LOGGER, Level.FINER, "class {0} was modified.", className);
         return cw.toByteArray();
     }
     
@@ -174,7 +174,7 @@ public class Transformer {
      */
     private int getBytecodeVersion(byte[] classData) {
         int version = (( classData[6] & 0xFF ) << 8 ) | (classData[7] & 0xFF);
-        LoggingHelper.conditionallyLog(LOGGER, Level.FINEST, "bytecode version is {0}", version);
+        LoggingHelper.asyncLog(LOGGER, Level.FINEST, "bytecode version is {0}", version);
         return version;
     }
 }

--- a/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/helper/LoggingHelper.java
+++ b/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/helper/LoggingHelper.java
@@ -26,9 +26,11 @@ public final class LoggingHelper {
     /** 
      * Logs to JUL if the log level is loggable for the given logger, based on the given message and parameters 
      * @param log the Logger to use.
-     * @param record the record to log
+     * @param level the level of the log entry
+     * @param message the message (with format placeholders) for the log entry
+     * @param parameters optional parameters to go with the message
      */
-    public static void asyncLog(final Logger log, final Level level, final String message, Object...parameters) {
+    public static void asyncLog(final Logger log, final Level level, final String message, final Object...parameters) {
         if (log.isLoggable(level)) {
             LogRecord record = new LogRecord(level, message);
             record.setParameters(parameters);
@@ -39,9 +41,12 @@ public final class LoggingHelper {
     /** 
      * Logs to JUL if the log level is loggable for the given logger, based on the given message and parameters 
      * @param log the Logger to use.
-     * @param record the record to log
+     * @param level the level of the log entry
+     * @param throwable the throwable to associate with the log entry
+     * @param message the message (with format placeholders) for the log entry
+     * @param parameters optional parameters to go with the message
      */
-    public static void asyncLog(final Logger log, final Level level, final Throwable throwable, final String message, Object...parameters) {
+    public static void asyncLog(final Logger log, final Level level, final Throwable throwable, final String message, final Object...parameters) {
         if (log.isLoggable(level)) {
             LogRecord record = new LogRecord(level, message);
             record.setThrown(throwable);

--- a/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/helper/LoggingHelper.java
+++ b/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/helper/LoggingHelper.java
@@ -1,0 +1,67 @@
+package org.jenkinsci.bytecode.helper;
+
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+/**
+ * Helper utility to allow asynchronous logging to prevent the introduction of deadlocks.
+ * We need this intermediate as logging can cause classloading and also involves locks, and the transformer is only ever
+ * invoked during class loading - so we should not really use logging as we could end up in a deadlock (however there
+ * are times where we really want to use it)
+ */
+public final class LoggingHelper {
+
+    /** 
+     * Logs to JUL if the records log level is loggable for the given logger. 
+     * @param log the Logger to use.
+     * @param record the record to log
+     */
+    public static void conditionallyLog(final Logger log, final LogRecord record) {
+        if (log.isLoggable(record.getLevel())) {
+            populateStackAndLogAsync(log, record);
+        }
+    }
+
+    /** 
+     * Logs to JUL if the log level is loggable for the given logger, based on the given message and parameters 
+     * @param log the Logger to use.
+     * @param record the record to log
+     */
+    public static void conditionallyLog(final Logger log, final Level level, final String message, Object...parameters) {
+        if (log.isLoggable(level)) {
+            LogRecord record = new LogRecord(level, message);
+            record.setParameters(parameters);
+            populateStackAndLogAsync(log, record);
+        }
+    }
+
+    /** 
+     * Logs to JUL if the log level is loggable for the given logger, based on the given message and parameters 
+     * @param log the Logger to use.
+     * @param record the record to log
+     */
+    public static void conditionallyLog(final Logger log, final Level level, final Throwable throwable, final String message, Object...parameters) {
+        if (log.isLoggable(level)) {
+            LogRecord record = new LogRecord(level, message);
+            record.setThrown(throwable);
+            record.setParameters(parameters);
+            populateStackAndLogAsync(log, record);
+        }
+    }
+
+    private static void populateStackAndLogAsync(final Logger log, final LogRecord record) {
+        // call to make sure the stack is populated.
+        StackTraceElement[] stack = Thread.currentThread().getStackTrace();
+        if (stack.length > 3) {
+            // [0] is Thrad.getStackTrace
+            // [1] is this method
+            // [2] is the caller (still this class)
+            // [3[ is the actual consumer we want
+            StackTraceElement caller = stack[3];
+            record.setSourceClassName(caller.getClassName());
+            record.setSourceMethodName(caller.getMethodName());
+        }
+        new Thread(() -> log.log(record), "bytecode-compatability-transformer async logging").start();
+    }
+}

--- a/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/helper/LoggingHelper.java
+++ b/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/helper/LoggingHelper.java
@@ -59,14 +59,14 @@ public final class LoggingHelper {
         // call to make sure the stack is populated.
         StackTraceElement[] stack = Thread.currentThread().getStackTrace();
         if (stack.length > 3) {
-            // [0] is Thrad.getStackTrace
+            // [0] is Thread.getStackTrace
             // [1] is this method
             // [2] is the caller (still this class)
-            // [3[ is the actual consumer we want
+            // [3] is the actual consumer we want
             StackTraceElement caller = stack[3];
             record.setSourceClassName(caller.getClassName());
             record.setSourceMethodName(caller.getMethodName());
         }
-        new Thread(() -> log.log(record), "bytecode-compatability-transformer async logging").start();
+        new Thread(() -> log.log(record), "bytecode-compatibility-transformer async logging").start();
     }
 }

--- a/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/helper/LoggingHelper.java
+++ b/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/helper/LoggingHelper.java
@@ -17,7 +17,7 @@ public final class LoggingHelper {
      * @param log the Logger to use.
      * @param record the record to log
      */
-    public static void conditionallyLog(final Logger log, final LogRecord record) {
+    public static void asyncLog(final Logger log, final LogRecord record) {
         if (log.isLoggable(record.getLevel())) {
             populateStackAndLogAsync(log, record);
         }
@@ -28,7 +28,7 @@ public final class LoggingHelper {
      * @param log the Logger to use.
      * @param record the record to log
      */
-    public static void conditionallyLog(final Logger log, final Level level, final String message, Object...parameters) {
+    public static void asyncLog(final Logger log, final Level level, final String message, Object...parameters) {
         if (log.isLoggable(level)) {
             LogRecord record = new LogRecord(level, message);
             record.setParameters(parameters);
@@ -41,7 +41,7 @@ public final class LoggingHelper {
      * @param log the Logger to use.
      * @param record the record to log
      */
-    public static void conditionallyLog(final Logger log, final Level level, final Throwable throwable, final String message, Object...parameters) {
+    public static void asyncLog(final Logger log, final Level level, final Throwable throwable, final String message, Object...parameters) {
         if (log.isLoggable(level)) {
             LogRecord record = new LogRecord(level, message);
             record.setThrown(throwable);

--- a/bytecode-compatibility-transformer/src/test/java/org/jenkinsci/bytecode/helper/LoggingHelperTest.java
+++ b/bytecode-compatibility-transformer/src/test/java/org/jenkinsci/bytecode/helper/LoggingHelperTest.java
@@ -1,0 +1,68 @@
+package org.jenkinsci.bytecode.helper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import org.junit.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.hamcrest.CoreMatchers.is;
+
+public class LoggingHelperTest {
+
+    @Test
+    public void testSourceCorrectlySetWhenLoggingARecord() throws Exception {
+        CapturingLogHandler h = new CapturingLogHandler();
+        Logger logger = Logger.getLogger("test-logger");
+        logger.addHandler(h);
+        
+        LogRecord lr = new LogRecord(Level.SEVERE, "this is a message");
+        LoggingHelper.asyncLog(logger, lr);
+        while (h.records.size() < 1) {
+            Thread.sleep(50L);
+        }
+        assertEquals(h.records.size(), 1);
+        assertThat(lr.getSourceClassName(), is("org.jenkinsci.bytecode.helper.LoggingHelperTest"));
+        assertThat(lr.getSourceMethodName(), is("testSourceCorrectlySetWhenLoggingARecord"));
+    }
+
+    @Test
+    public void testSourceCorrectlySetWhenLoggingAMessage() throws Exception {
+        CapturingLogHandler h = new CapturingLogHandler();
+        Logger logger = Logger.getLogger("test-logger");
+        logger.addHandler(h);
+        
+        LoggingHelper.asyncLog(logger, Level.INFO, new Throwable(), "this is a message");
+        while (h.records.size() < 1) {
+            Thread.sleep(50L);
+        }
+        assertEquals(h.records.size(), 1);
+        assertThat(h.records.get(0).getSourceClassName(), is("org.jenkinsci.bytecode.helper.LoggingHelperTest"));
+        assertThat(h.records.get(0).getSourceMethodName(), is("testSourceCorrectlySetWhenLoggingAMessage"));
+    }
+
+
+    private static class CapturingLogHandler extends Handler {
+
+        private List<LogRecord> records = new ArrayList<>();
+
+        @Override
+        public void publish(LogRecord record) {
+            records.add(record);
+        }
+
+        @Override
+        public void flush() {
+            // no-op
+        }
+
+        @Override
+        public void close() throws SecurityException {
+            // no-op
+        }
+    }
+}


### PR DESCRIPTION
[JENKINS-64479](https://issues.jenkins.io/browse/JENKINS-64479)

Logging during classloading is a surefire way to deadlock.
but we still want to have logs and in some cases we also want those logs
to be in the same place as other logs.

So introduce a new helper that punts the logging to a new Thread so that
we do not deadlock.

alternative to #17 based on suggestion by @jglick 