### PR TITLE
Revert "Stop using repackaged ASM; upgrade ASM to 9.1"

### DIFF
--- a/bytecode-compatibility-transformer/pom.xml
+++ b/bytecode-compatibility-transformer/pom.xml
@@ -13,10 +13,6 @@
   <name>Bytecode transformation-based library for managing backward compatibility</name>
   <version>2.1-SNAPSHOT</version>
 
-  <properties>
-    <asm.version>9.1</asm.version>
-  </properties>
-
   <build>
     <plugins>
       <plugin>
@@ -46,14 +42,9 @@
       <version>1.4</version>
     </dependency>
     <dependency>
-      <groupId>org.ow2.asm</groupId>
-      <artifactId>asm</artifactId>
-      <version>${asm.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.ow2.asm</groupId>
-      <artifactId>asm-commons</artifactId>
-      <version>${asm.version}</version>
+      <groupId>org.kohsuke</groupId>
+      <artifactId>asm6</artifactId>
+      <version>6.2</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>

--- a/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/AdaptField.java
+++ b/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/AdaptField.java
@@ -1,8 +1,8 @@
 package org.jenkinsci.bytecode;
 
 import org.jvnet.hudson.annotation_indexer.Indexed;
-import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Type;
+import org.kohsuke.asm6.MethodVisitor;
+import org.kohsuke.asm6.Type;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -14,7 +14,7 @@ import java.lang.reflect.Modifier;
 
 import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.*;
-import static org.objectweb.asm.Opcodes.*;
+import static org.kohsuke.asm6.Opcodes.*;
 
 /**
  * Rewrites a field reference by adapting the type of the field.

--- a/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/ClassRewritingContext.java
+++ b/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/ClassRewritingContext.java
@@ -1,16 +1,16 @@
 package org.jenkinsci.bytecode;
 
-import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.Label;
-import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.Type;
+import org.kohsuke.asm6.ClassVisitor;
+import org.kohsuke.asm6.Label;
+import org.kohsuke.asm6.MethodVisitor;
+import org.kohsuke.asm6.Opcodes;
+import org.kohsuke.asm6.Type;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import static org.objectweb.asm.Opcodes.*;
+import static org.kohsuke.asm6.Opcodes.*;
 
 /**
  * Remembers what class is being rewritten and what helper methods need to be generated into this class.

--- a/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/Kind.java
+++ b/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/Kind.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.bytecode;
 
-import org.objectweb.asm.MethodVisitor;
+import org.kohsuke.asm6.MethodVisitor;
 
 /**
  * Rewriting a method reference and a field reference takes a very similar code path,

--- a/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/MemberAdapter.java
+++ b/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/MemberAdapter.java
@@ -1,7 +1,7 @@
 package org.jenkinsci.bytecode;
 
-import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Type;
+import org.kohsuke.asm6.MethodVisitor;
+import org.kohsuke.asm6.Type;
 
 import java.lang.reflect.Member;
 

--- a/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/MemberTransformSpec.java
+++ b/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/MemberTransformSpec.java
@@ -1,15 +1,15 @@
 package org.jenkinsci.bytecode;
 
-import org.objectweb.asm.Label;
-import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Type;
+import org.kohsuke.asm6.Label;
+import org.kohsuke.asm6.MethodVisitor;
+import org.kohsuke.asm6.Type;
 
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import static org.objectweb.asm.Opcodes.*;
+import static org.kohsuke.asm6.Opcodes.*;
 
 /**
  * All the adapters of {@linkplain #kind a specific member type} keyed by their name and descriptor.

--- a/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/NonClassLoadingClassWriter.java
+++ b/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/NonClassLoadingClassWriter.java
@@ -27,7 +27,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.jenkinsci.bytecode.helper.ClassLoadingReferenceTypeHierachyReader;
-import org.objectweb.asm.ClassWriter;
+import org.kohsuke.asm6.ClassWriter;
 
 
 

--- a/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/Transformer.java
+++ b/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/Transformer.java
@@ -1,10 +1,10 @@
 package org.jenkinsci.bytecode;
 
-import org.objectweb.asm.ClassReader;
-import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.commons.JSRInlinerAdapter;
+import org.kohsuke.asm6.ClassReader;
+import org.kohsuke.asm6.ClassVisitor;
+import org.kohsuke.asm6.ClassWriter;
+import org.kohsuke.asm6.MethodVisitor;
+import org.kohsuke.asm6.commons.JSRInlinerAdapter;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -12,7 +12,7 @@ import java.util.Collections;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static org.objectweb.asm.Opcodes.*;
+import static org.kohsuke.asm6.Opcodes.*;
 
 /**
  * Transform byte code where code references bytecode rewrite annotations.
@@ -95,13 +95,13 @@ public class Transformer {
         // If code contains JSR/RET instructions then ASM fails to transform it with
         // java.lang.RuntimeException: JSR/RET are not supported with computeFrames option
         // so inline any JSR subroutines
-        ClassVisitor jsrInliner = new ClassVisitor(ASM9,cw) {
+        ClassVisitor jsrInliner = new ClassVisitor(ASM5,cw) {
             
             @Override
             public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
                 final MethodVisitor base = super.visitMethod(access, name, desc, signature, exceptions);
                 LOGGER.log(Level.FINEST, "jsrInliner.visitMethod({0}, {1}, {2}, {3}, {4})", new Object[] {access, name, desc, signature, exceptions});
-                return new JSRInlinerAdapter(ASM9, base, access, name, desc, signature, exceptions) {
+                return new JSRInlinerAdapter(ASM5, base, access, name, desc, signature, exceptions) {
 
                    @Override
                     public void visitEnd() {
@@ -112,7 +112,7 @@ public class Transformer {
             }
         };
         
-        cr.accept(new ClassVisitor(ASM9, regenerateStackMapTable ? jsrInliner : cw) {
+        cr.accept(new ClassVisitor(ASM5, regenerateStackMapTable ? jsrInliner : cw) {
             private ClassRewritingContext context;
 
             @Override
@@ -126,7 +126,7 @@ public class Transformer {
             public MethodVisitor visitMethod(int access, final String methodName, final String methodDescriptor, final String methodSignature, String[] exceptions) {
                 final MethodVisitor base = super.visitMethod(access, methodName, methodDescriptor, methodSignature, exceptions);
 
-                return new MethodVisitor(ASM9,base) {
+                return new MethodVisitor(ASM5,base) {
                     @Override
                     public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
                         boolean _modified = spec.methods.rewrite(context,opcode,owner,name,desc, itf, base);

--- a/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/helper/ClassLoadingReferenceTypeHierachyReader.java
+++ b/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/helper/ClassLoadingReferenceTypeHierachyReader.java
@@ -28,8 +28,8 @@ import java.io.InputStream;
 import java.net.URL;
 
 import org.apache.commons.io.IOUtils;
-import org.objectweb.asm.ClassReader;
-import org.objectweb.asm.Type;
+import org.kohsuke.asm6.ClassReader;
+import org.kohsuke.asm6.Type;
 
 /**
  * A {@link TypeHierarchyReader} that uses a given ClassLoader to locate class definitions.

--- a/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/helper/TypeHierarchyReader.java
+++ b/bytecode-compatibility-transformer/src/main/java/org/jenkinsci/bytecode/helper/TypeHierarchyReader.java
@@ -34,8 +34,8 @@ package org.jenkinsci.bytecode.helper;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
-import static org.objectweb.asm.Opcodes.ACC_INTERFACE;
-import static org.objectweb.asm.Type.getType;
+import static org.kohsuke.asm6.Opcodes.ACC_INTERFACE;
+import static org.kohsuke.asm6.Type.getType;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -44,8 +44,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.objectweb.asm.ClassReader;
-import org.objectweb.asm.Type;
+import org.kohsuke.asm6.ClassReader;
+import org.kohsuke.asm6.Type;
 
 import static org.jenkinsci.bytecode.helper.TypeHierarchyReader.TypeHierarchy.BOOLEAN_HIERARCHY;
 import static org.jenkinsci.bytecode.helper.TypeHierarchyReader.TypeHierarchy.BYTE_HIERARCHY;

--- a/bytecode-compatibility-transformer/src/test/java/org/jenkinsci/bytecode/NonClassLoadingClassWriterTest.java
+++ b/bytecode-compatibility-transformer/src/test/java/org/jenkinsci/bytecode/NonClassLoadingClassWriterTest.java
@@ -37,8 +37,8 @@ import java.util.TreeSet;
 
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
-import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.Opcodes;
+import org.kohsuke.asm6.ClassWriter;
+import org.kohsuke.asm6.Opcodes;
 
 import static org.junit.Assert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -80,8 +80,8 @@ public class NonClassLoadingClassWriterTest {
      * Checks that the 
      */
     public void assertCommonSuperClass(Class<?> class1, Class<?> class2) {
-        NonClassLoadingClassWriter writerUnderTest = new NonClassLoadingClassWriter(NonClassLoadingClassWriterTest.class.getClassLoader(), Opcodes.ASM9);
-        OrgClassWriter orgWriter = new OrgClassWriter(Opcodes.ASM9);
+        NonClassLoadingClassWriter writerUnderTest = new NonClassLoadingClassWriter(NonClassLoadingClassWriterTest.class.getClassLoader(), Opcodes.ASM5);
+        OrgClassWriter orgWriter = new OrgClassWriter(Opcodes.ASM5);
 
         String cls1 = class1.getName().replace('.', '/');
         String cls2 = class2.getName().replace('.', '/');

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.63</version>
+    <version>1.46</version>
   </parent>
 
   <groupId>org.jenkins-ci.main.bct</groupId>


### PR DESCRIPTION
Reverts jenkinsci/bytecode-compatibility-transformer#23

ASM does not evlove in a compatable way - expsogin pute ASM from jenkins core is a mistake as plugins will break for version upgrades if they do not package it themselves and use maskCLasses.

Its introduction with jnr-posix was a mistake that should be fixed.